### PR TITLE
refactor: typo

### DIFF
--- a/adminSDK/directory/index.html
+++ b/adminSDK/directory/index.html
@@ -57,14 +57,14 @@ limitations under the License.
        * Callback after api.js is loaded.
        */
       function gapiLoaded() {
-        gapi.load('client', intializeGapiClient);
+        gapi.load('client', initializeGapiClient);
       }
 
       /**
        * Callback after the API client is loaded. Loads the
        * discovery doc to initialize the API.
        */
-      async function intializeGapiClient() {
+      async function initializeGapiClient() {
         await gapi.client.init({
           apiKey: API_KEY,
           discoveryDocs: [DISCOVERY_DOC],

--- a/adminSDK/reports/index.html
+++ b/adminSDK/reports/index.html
@@ -57,14 +57,14 @@ limitations under the License.
        * Callback after api.js is loaded.
        */
       function gapiLoaded() {
-        gapi.load('client', intializeGapiClient);
+        gapi.load('client', initializeGapiClient);
       }
 
       /**
        * Callback after the API client is loaded. Loads the
        * discovery doc to initialize the API.
        */
-      async function intializeGapiClient() {
+      async function initializeGapiClient() {
         await gapi.client.init({
           apiKey: API_KEY,
           discoveryDocs: [DISCOVERY_DOC],

--- a/adminSDK/reseller/index.html
+++ b/adminSDK/reseller/index.html
@@ -57,14 +57,14 @@ limitations under the License.
        * Callback after api.js is loaded.
        */
       function gapiLoaded() {
-        gapi.load('client', intializeGapiClient);
+        gapi.load('client', initializeGapiClient);
       }
 
       /**
        * Callback after the API client is loaded. Loads the
        * discovery doc to initialize the API.
        */
-      async function intializeGapiClient() {
+      async function initializeGapiClient() {
         await gapi.client.init({
           apiKey: API_KEY,
           discoveryDocs: [DISCOVERY_DOC],

--- a/apps-script/quickstart/index.html
+++ b/apps-script/quickstart/index.html
@@ -57,14 +57,14 @@ limitations under the License.
        * Callback after api.js is loaded.
        */
       function gapiLoaded() {
-        gapi.load('client', intializeGapiClient);
+        gapi.load('client', initializeGapiClient);
       }
 
       /**
        * Callback after the API client is loaded. Loads the
        * discovery doc to initialize the API.
        */
-      async function intializeGapiClient() {
+      async function initializeGapiClient() {
         await gapi.client.init({
           apiKey: API_KEY,
           discoveryDocs: [DISCOVERY_DOC],

--- a/calendar/quickstart/index.html
+++ b/calendar/quickstart/index.html
@@ -57,14 +57,14 @@ limitations under the License.
        * Callback after api.js is loaded.
        */
       function gapiLoaded() {
-        gapi.load('client', intializeGapiClient);
+        gapi.load('client', initializeGapiClient);
       }
 
       /**
        * Callback after the API client is loaded. Loads the
        * discovery doc to initialize the API.
        */
-      async function intializeGapiClient() {
+      async function initializeGapiClient() {
         await gapi.client.init({
           apiKey: API_KEY,
           discoveryDocs: [DISCOVERY_DOC],

--- a/classroom/quickstart/index.html
+++ b/classroom/quickstart/index.html
@@ -57,14 +57,14 @@ limitations under the License.
        * Callback after api.js is loaded.
        */
       function gapiLoaded() {
-        gapi.load('client', intializeGapiClient);
+        gapi.load('client', initializeGapiClient);
       }
 
       /**
        * Callback after the API client is loaded. Loads the
        * discovery doc to initialize the API.
        */
-      async function intializeGapiClient() {
+      async function initializeGapiClient() {
         await gapi.client.init({
           apiKey: API_KEY,
           discoveryDocs: [DISCOVERY_DOC],

--- a/docs/quickstart/index.html
+++ b/docs/quickstart/index.html
@@ -57,14 +57,14 @@ limitations under the License.
        * Callback after api.js is loaded.
        */
       function gapiLoaded() {
-        gapi.load('client', intializeGapiClient);
+        gapi.load('client', initializeGapiClient);
       }
 
       /**
        * Callback after the API client is loaded. Loads the
        * discovery doc to initialize the API.
        */
-      async function intializeGapiClient() {
+      async function initializeGapiClient() {
         await gapi.client.init({
           apiKey: API_KEY,
           discoveryDocs: [DISCOVERY_DOC],

--- a/drive/activity-v2/index.html
+++ b/drive/activity-v2/index.html
@@ -57,14 +57,14 @@ limitations under the License.
        * Callback after api.js is loaded.
        */
       function gapiLoaded() {
-        gapi.load('client', intializeGapiClient);
+        gapi.load('client', initializeGapiClient);
       }
 
       /**
        * Callback after the API client is loaded. Loads the
        * discovery doc to initialize the API.
        */
-      async function intializeGapiClient() {
+      async function initializeGapiClient() {
         await gapi.client.init({
           apiKey: API_KEY,
           discoveryDocs: [DISCOVERY_DOC],

--- a/gmail/quickstart/index.html
+++ b/gmail/quickstart/index.html
@@ -57,14 +57,14 @@ limitations under the License.
        * Callback after api.js is loaded.
        */
       function gapiLoaded() {
-        gapi.load('client', intializeGapiClient);
+        gapi.load('client', initializeGapiClient);
       }
 
       /**
        * Callback after the API client is loaded. Loads the
        * discovery doc to initialize the API.
        */
-      async function intializeGapiClient() {
+      async function initializeGapiClient() {
         await gapi.client.init({
           apiKey: API_KEY,
           discoveryDocs: [DISCOVERY_DOC],

--- a/people/quickstart/index.html
+++ b/people/quickstart/index.html
@@ -58,14 +58,14 @@ limitations under the License.
        * Callback after api.js is loaded.
        */
       function gapiLoaded() {
-        gapi.load('client', intializeGapiClient);
+        gapi.load('client', initializeGapiClient);
       }
 
       /**
        * Callback after the API client is loaded. Loads the
        * discovery doc to initialize the API.
        */
-      async function intializeGapiClient() {
+      async function initializeGapiClient() {
         await gapi.client.init({
           apiKey: API_KEY,
           discoveryDocs: [DISCOVERY_DOC],

--- a/sheets/quickstart/index.html
+++ b/sheets/quickstart/index.html
@@ -57,14 +57,14 @@ limitations under the License.
        * Callback after api.js is loaded.
        */
       function gapiLoaded() {
-        gapi.load('client', intializeGapiClient);
+        gapi.load('client', initializeGapiClient);
       }
 
       /**
        * Callback after the API client is loaded. Loads the
        * discovery doc to initialize the API.
        */
-      async function intializeGapiClient() {
+      async function initializeGapiClient() {
         await gapi.client.init({
           apiKey: API_KEY,
           discoveryDocs: [DISCOVERY_DOC],

--- a/sheets/snippets/index.html
+++ b/sheets/snippets/index.html
@@ -87,14 +87,14 @@
        * Callback after api.js is loaded.
        */
       function gapiLoaded() {
-        gapi.load('client', intializeGapiClient);
+        gapi.load('client', initializeGapiClient);
       }
 
       /**
        * Callback after the API client is loaded. Loads the
        * discovery doc to initialize the API.
        */
-      async function intializeGapiClient() {
+      async function initializeGapiClient() {
         await gapi.client.init({
           apiKey: API_KEY,
           discoveryDocs: DISCOVERY_DOCS,

--- a/slides/quickstart/index.html
+++ b/slides/quickstart/index.html
@@ -57,14 +57,14 @@ limitations under the License.
        * Callback after api.js is loaded.
        */
       function gapiLoaded() {
-        gapi.load('client', intializeGapiClient);
+        gapi.load('client', initializeGapiClient);
       }
 
       /**
        * Callback after the API client is loaded. Loads the
        * discovery doc to initialize the API.
        */
-      async function intializeGapiClient() {
+      async function initializeGapiClient() {
         await gapi.client.init({
           apiKey: API_KEY,
           discoveryDocs: [DISCOVERY_DOC],

--- a/slides/snippets/index.html
+++ b/slides/snippets/index.html
@@ -92,13 +92,13 @@
        * Callback after api.js is loaded.
        */
       function gapiLoaded() {
-        gapi.load('client', intializeGapiClient);
+        gapi.load('client', initializeGapiClient);
       }
       /**
        * Callback after the API client is loaded. Loads the
        * discovery doc to initialize the API.
        */
-      async function intializeGapiClient() {
+      async function initializeGapiClient() {
         await gapi.client.init({
           apiKey: API_KEY,
           discoveryDocs: DISCOVERY_DOCS,

--- a/tasks/quickstart/index.html
+++ b/tasks/quickstart/index.html
@@ -57,14 +57,14 @@ limitations under the License.
        * Callback after api.js is loaded.
        */
       function gapiLoaded() {
-        gapi.load('client', intializeGapiClient);
+        gapi.load('client', initializeGapiClient);
       }
 
       /**
        * Callback after the API client is loaded. Loads the
        * discovery doc to initialize the API.
        */
-      async function intializeGapiClient() {
+      async function initializeGapiClient() {
         await gapi.client.init({
           apiKey: API_KEY,
           discoveryDocs: [DISCOVERY_DOC],


### PR DESCRIPTION
initializeGapiClient was intializeGapiClient in almost every quickstart