### PR TITLE
Update README.md

### DIFF
--- a/gmail/quickstart/README.md
+++ b/gmail/quickstart/README.md
@@ -9,8 +9,16 @@ Gmail API.
 
 After following the quickstart instructions, run the sample:
 
+In your working directory, install the [http-server](https://www.npmjs.com/package/http-server) package:
+
 ```shell
-python3 -m http.server 8000
+npm install http-server
+```
+
+In your working directory, start a web server:
+
+```shell
+npx http-server -p 8000
 ```
 
 And opening the web page:


### PR DESCRIPTION
In the [Quick Start Guide](https://developers.google.com/gmail/api/quickstart/js), python is not listed as a prerequisite and even though python would likely be installed, it is unnecessary to use it for the web server. Using node simplifies it (It also contrasts the example running instructions on the quick start page).

really small change, not even worth a pull request but just bugged me. sorry 😅